### PR TITLE
Ajuste para remover barra de rolagem lateral em telas pequenas

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,9 +11,20 @@
     outline: none;
 }
 
+body::-webkit-scrollbar {
+    width: 10px;
+}
+
+body::-webkit-scrollbar-track {
+    background: #1f1f1f;
+}
+
+body::-webkit-scrollbar-thumb {
+    background-color: #454545;
+    border-radius: 20px;
+}
+
 body {
-    width: 100vw;
-    height: 100vh;
     display: flex;
     align-items: center;
     flex-direction: column;


### PR DESCRIPTION
- As propriedades `width: 100vw;` e `height: 100vh;` estavam criando barra de rolagem horizontal em telas menores (meu notebook por exemplo kkk). Essas propriedades não são mais necessárias já que não é mais usado flex para centralizar o componente principal.
- Adicionado uma pequena estilização na barra de rolagem lateral para combinar com o tema escuro do layout